### PR TITLE
ci: upgrade GitHub Actions from v3 to v4

### DIFF
--- a/.github/workflows/webpilot-vue3.yml
+++ b/.github/workflows/webpilot-vue3.yml
@@ -24,10 +24,10 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -59,7 +59,7 @@ jobs:
         run: pnpm run build
 
       - name: Pack Extension
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webpilot
           path: build


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/